### PR TITLE
docs: add conventional commits guide

### DIFF
--- a/Issue-Creation/Issue-Creation.md
+++ b/Issue-Creation/Issue-Creation.md
@@ -1,0 +1,34 @@
+# Issue Creation Guide
+
+This guide explains how students should create issues when contributing to the Seattle Colleges Application Development Practicum repositories.
+
+## Purpose
+
+Issues help track work, report bugs, suggest improvements, and organize development tasks. Creating clear issues helps the team collaborate effectively.
+
+## Steps to Create an Issue
+
+1. Navigate to the repository on GitHub.
+2. Click on the **Issues** tab.
+3. Click the **New Issue** button.
+4. Enter a clear and descriptive **Title**.
+5. Provide the following details in the description:
+
+   - **Related Problem**  
+     Describe the problem or missing feature.
+
+   - **Proposed Solution**  
+     Explain how the problem could be solved.
+
+   - **Relevant Resources**  
+     Include links, documentation, or tutorials if applicable.
+
+6. Assign the issue to yourself if you plan to work on it.
+7. Add appropriate labels if needed.
+
+
+## Best Practices
+
+- Write clear and concise issue descriptions.
+- Check existing issues before creating a new one.
+- Provide screenshots or examples this will be helpful.


### PR DESCRIPTION
Added documentation referencing **Conventional Commits** to the Practicum Wiki to guide students on writing standardized commit messages.

Includes:

* Link to the official Conventional Commits specification
* Explanation of why standardized commit messages are important
* Examples of common commit types such as `feat`, `fix`, and `docs`

Fixes #45
