### PR TITLE
SeattleColleges-AD-Practicum-Wiki_44_documentation-team-directory-page

### DIFF
--- a/docs/team-directory.md
+++ b/docs/team-directory.md
@@ -16,23 +16,27 @@ This page lists all current members of the NSC AD Practicum team. Each member sh
 
 ## 👨‍💻 Current Students
 
-| Name | GitHub | Role | Active Project(s) |
-|------|--------|------|-------------------|
-| Ermiy Hailemichael | [@ErmiyasHailemichael](https://github.com/ErmiyasHailemichael) | Developer | TBD |
-| *(Your Name)* | [@yourusername](https://github.com/yourusername) | Developer | *(Project Name)* |
-| *(Your Name)* | [@yourusername](https://github.com/yourusername) | Developer | *(Project Name)* |
-| *(Your Name)* | [@yourusername](https://github.com/yourusername) | Developer | *(Project Name)* |
+| Name | GitHub | Role | Track | Active Project(s) |
+|------|--------|------|-------|-------------------|
+| Ermiy Hailemichael | [@ErmiyasHailemichael](https://github.com/ErmiyasHailemichael) | Developer | TBD | TBD |
 
 ---
 
 ## 📋 How to Update This Page
 
 1. Click **Edit** at the top right of this wiki page.
-2. Add a new row to the **Current Students** table using the format above.
-3. Include your full name, a link to your GitHub profile, your role, and the project(s) you're currently contributing to.
+2. Add a new row to the **Current Students** table using the format below.
+3. Include your full name, a link to your GitHub profile, your role, your track, and the project(s) you're currently contributing to.
 4. Save your changes with a brief edit summary (e.g., `docs: add [Your Name] to team directory`).
 
+**Row format example:**
+```markdown
+| Your Name | [@yourusername](https://github.com/yourusername) | Developer | Frontend Dev | Project Name |
+```
+
 > 💡 For role definitions, see the [Team Structure & Roles](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Team-Structure-and-Roles) page.
+>
+> 💡 Example track values: `Frontend Dev`, `Backend Dev`, `Documentation`, `PM`
 
 ---
 
@@ -40,4 +44,4 @@ This page lists all current members of the NSC AD Practicum team. Each member sh
 
 [Home](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Home) • [New Student Onboarding](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/New-Student-Onboarding) • [Guides](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Guides-and-Resources) • [Projects](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Active-Projects) • [Code of Conduct](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Code-of-Conduct) • [FAQ](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/FAQ)
 
-*Last updated: 5/12/2026*
+*Last updated: 5/17/2026*

--- a/docs/team-directory.md
+++ b/docs/team-directory.md
@@ -1,0 +1,43 @@
+# 👥 Team Directory
+
+This page lists all current members of the NSC AD Practicum team. Each member should keep their entry up to date with their current role and active project(s).
+
+> 📝 **Team Members:** To add or update your entry, edit this page and follow the format below.
+
+---
+
+## 🧑‍💼 Program Leadership
+
+| Name | GitHub | Role |
+|------|--------|------|
+| Jesse Caddell | [@JesseCaddell](https://github.com/JesseCaddell) | Instructor / Program Lead |
+
+---
+
+## 👨‍💻 Current Students
+
+| Name | GitHub | Role | Active Project(s) |
+|------|--------|------|-------------------|
+| Ermiy Hailemichael | [@ErmiyasHailemichael](https://github.com/ErmiyasHailemichael) | Developer | TBD |
+| *(Your Name)* | [@yourusername](https://github.com/yourusername) | Developer | *(Project Name)* |
+| *(Your Name)* | [@yourusername](https://github.com/yourusername) | Developer | *(Project Name)* |
+| *(Your Name)* | [@yourusername](https://github.com/yourusername) | Developer | *(Project Name)* |
+
+---
+
+## 📋 How to Update This Page
+
+1. Click **Edit** at the top right of this wiki page.
+2. Add a new row to the **Current Students** table using the format above.
+3. Include your full name, a link to your GitHub profile, your role, and the project(s) you're currently contributing to.
+4. Save your changes with a brief edit summary (e.g., `docs: add [Your Name] to team directory`).
+
+> 💡 For role definitions, see the [Team Structure & Roles](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Team-Structure-and-Roles) page.
+
+---
+
+### 📘 Navigation
+
+[Home](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Home) • [New Student Onboarding](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/New-Student-Onboarding) • [Guides](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Guides-and-Resources) • [Projects](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Active-Projects) • [Code of Conduct](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Code-of-Conduct) • [FAQ](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/FAQ)
+
+*Last updated: 5/12/2026*


### PR DESCRIPTION
## Summary & Changes 📃
- **Resolves:** `#44`
- **Summary:**
  - 🔨 The Team Directory wiki page existed but had no content ("coming soon!"). This PR adds the full page content.
  - 👀 The Team Directory page should display a structured table of program leadership and current students with GitHub profile links and active projects.
  - 🗨️ Content was added both to the wiki directly and mirrored in `docs/team-directory.md` for version control.
- **Changes:**
  - ✅ Created `docs/team-directory.md` with team directory content
  - ✅ Added Program Leadership section with instructor entry
  - ✅ Added Current Students table with placeholder rows for teammates to fill in
  - ✅ Added "How to Update This Page" instructions for future contributors
  - 🔗 Wiki page updated: https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Team-Directory

## Screenshots / Visual Aids 🔎
<sub><i>📌 **Required for:** UI changes, layout updates, or bug fixes.</i></sub>
<details>
  <summary> Expand ⬇️ </summary>
  <!-- Screenshot of the updated wiki Team Directory page -->
<img width="2202" height="1193" alt="Screenshot 2026-05-12 at 9 31 30 PM" src="https://github.com/user-attachments/assets/a0f87ce1-a190-432a-a95e-c079eecc595a" />
</details>

## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Navigate to the [Team Directory wiki page](https://github.com/SeattleColleges/SeattleColleges-AD-Practicum-Wiki/wiki/Team-Directory)
   - Step 2: Verify the page displays the leadership table, current students table, and update instructions
2. **Expected Behavior:** A fully populated Team Directory page with structured tables and navigation links.

## Checklist ✅
- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #44`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned.
- [ ] **Squash commits** and enable **auto-merge** if approved.